### PR TITLE
[3.2.1] Made channel, user and role resolvers more lenient

### DIFF
--- a/src/main/java/de/nevini/resolvers/common/ChannelResolver.java
+++ b/src/main/java/de/nevini/resolvers/common/ChannelResolver.java
@@ -33,9 +33,15 @@ public class ChannelResolver extends AbstractResolver<TextChannel> {
 
     @Override
     public List<TextChannel> findSorted(@NonNull CommandEvent event, String query) {
-        return FinderUtil.findTextChannels(query, event.getGuild()).stream()
+        List<TextChannel> matches = FinderUtil.findTextChannels(query, event.getGuild()).stream()
                 .sorted(Comparator.comparing(TextChannel::getName))
                 .collect(Collectors.toList());
+
+        if (matches.isEmpty() && query.startsWith("#")) {
+            return findSorted(event, query.substring(1));
+        } else {
+            return matches;
+        }
     }
 
     @Override

--- a/src/main/java/de/nevini/resolvers/common/MemberResolver.java
+++ b/src/main/java/de/nevini/resolvers/common/MemberResolver.java
@@ -34,19 +34,24 @@ public class MemberResolver extends AbstractResolver<Member> {
 
     @Override
     public List<Member> findSorted(@NonNull CommandEvent event, String query) {
-        List<Member> discordMatches = FinderUtil.findMembers(query, event.getGuild()).stream()
+        List<Member> matches = FinderUtil.findMembers(query, event.getGuild()).stream()
                 .filter(m -> !m.getUser().isBot())
                 .sorted(Comparator.comparing(Member::getEffectiveName))
                 .collect(Collectors.toList());
-        if (discordMatches.isEmpty()) {
-            return event.getIgnService().findByIgn(event.getGuild(), query).stream()
+
+        if (matches.isEmpty()) {
+            matches = event.getIgnService().findByIgn(event.getGuild(), query).stream()
                     .map(data -> event.getGuild().getMemberById(data.getUser()))
                     .filter(Objects::nonNull)
                     .sorted(Comparator.comparing(Member::getEffectiveName))
                     .distinct()
                     .collect(Collectors.toList());
+        }
+
+        if (matches.isEmpty() && (query.startsWith("@") || query.startsWith("!"))) {
+            return findSorted(event, query.substring(1));
         } else {
-            return discordMatches;
+            return matches;
         }
     }
 

--- a/src/main/java/de/nevini/resolvers/common/RoleResolver.java
+++ b/src/main/java/de/nevini/resolvers/common/RoleResolver.java
@@ -32,9 +32,15 @@ public class RoleResolver extends AbstractResolver<Role> {
 
     @Override
     public List<Role> findSorted(@NonNull CommandEvent event, String query) {
-        return FinderUtil.findRoles(query, event.getGuild()).stream()
+        List<Role> matches = FinderUtil.findRoles(query, event.getGuild()).stream()
                 .sorted(Comparator.comparing(Role::getPosition).reversed())
                 .collect(Collectors.toList());
+
+        if (matches.isEmpty() && (query.startsWith("@") || query.startsWith("&"))) {
+            return findSorted(event, query.substring(1));
+        } else {
+            return matches;
+        }
     }
 
     @Override


### PR DESCRIPTION
* `ChannelResolver` will trim leading `#` if no matches are found
* `MemberResolver` will trim leading `@` and `!` if no matches are found
* `RoleResolver` will trim leading `@` and `&` if no matches are found